### PR TITLE
fix apt key for wavefront proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ wavefront_create_cred_file: false
 
 wavefront_proxy_pkg_url: 'https://packagecloud.io/wavefront/proxy'
 wavefront_telegraf_pkg_url: 'https://packagecloud.io/wavefront/telegraf'
+wavefront_repo_gpgkey: "https://packagecloud.io/wavefront/proxy/gpgkey"
 wavefront_pkg_state: 'installed'
 
 # to set a version of the agent use wavefront-proxy=X.Y.Z

--- a/tasks/packages/Debian.yml
+++ b/tasks/packages/Debian.yml
@@ -16,7 +16,7 @@
 
 - name: Add Wavefront apt repository key.
   apt_key:
-    url: https://packagecloud.io/wavefront/proxy-next/gpgkey
+    url: url: "{{ wavefront_repo_gpgkey }}"
     state: present
     validate_certs: no
   when: wavefront_install_proxy == "true"


### PR DESCRIPTION

* flipped apt_key url to variable
* fixed url as noted in https://github.com/wavefrontHQ/wavefront-ansible/issues/2